### PR TITLE
Reset attrs when manual reinitalize trigger received

### DIFF
--- a/src/angular-vs-repeat.js
+++ b/src/angular-vs-repeat.js
@@ -408,7 +408,11 @@
                             $scrollParent.off('scroll', scrollHandler);
                         });
 
-                        $scope.$on('vsRepeatTrigger', refresh);
+                        $scope.$on('vsRepeatTrigger', function() {
+                            $scope.overrideStartIndex = $scope.$eval($attrs.vsOverrideStartIndex);
+                            $scope.startIndex =  $scope.$eval($attrs.startIndex) || 0;
+                            refresh();
+                        });
 
                         $scope.$on('vsRepeatResize', function() {
                             autoSize = true;


### PR DESCRIPTION
When we receive a reinitialize trigger to vs-scroll the attrs has to be reset for it to resize and update collection according new attr values for the directive.
